### PR TITLE
Upload de imagens para um produto

### DIFF
--- a/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/product/Product.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/product/Product.java
@@ -3,12 +3,16 @@ package br.com.zupacademy.ggwadera.mercadolivre.product;
 import br.com.zupacademy.ggwadera.mercadolivre.category.Category;
 import br.com.zupacademy.ggwadera.mercadolivre.product.feature.NewProductFeatureRequest;
 import br.com.zupacademy.ggwadera.mercadolivre.product.feature.ProductFeature;
+import br.com.zupacademy.ggwadera.mercadolivre.product.picture.ProductPicture;
 import br.com.zupacademy.ggwadera.mercadolivre.user.User;
 import org.springframework.util.Assert;
 
 import javax.persistence.*;
 import java.math.BigDecimal;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Entity
@@ -34,10 +38,45 @@ public class Product {
     private Category category;
 
     @OneToMany(orphanRemoval = true, cascade = CascadeType.ALL, mappedBy = "product")
-    private Collection<ProductFeature> features;
+    private Set<ProductFeature> features;
+
+    @OneToMany(orphanRemoval = true, cascade = CascadeType.ALL, mappedBy = "product")
+    private Set<ProductPicture> pictures = new HashSet<>();
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     private User user;
+
+    public boolean belongsTo(User user) {
+        return this.user.equals(user);
+    }
+
+    public void addPictures(Collection<String> picturesUri) {
+        Set<ProductPicture> pictures = picturesUri.stream()
+            .map(uri -> new ProductPicture(uri, this))
+            .collect(Collectors.toSet());
+        this.pictures.addAll(pictures);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Product product = (Product) o;
+        return id.equals(product.getId()) && name.equals(product.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
 
     public static final class Builder {
         private String name;

--- a/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/product/ProductController.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/product/ProductController.java
@@ -1,36 +1,64 @@
 package br.com.zupacademy.ggwadera.mercadolivre.product;
 
+import br.com.zupacademy.ggwadera.mercadolivre.product.picture.NewPicturesRequest;
+import br.com.zupacademy.ggwadera.mercadolivre.product.picture.Uploader;
 import br.com.zupacademy.ggwadera.mercadolivre.security.AuthenticatedUser;
 import br.com.zupacademy.ggwadera.mercadolivre.user.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
 import javax.validation.Valid;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/produtos")
 @Transactional
 public class ProductController {
 
+    private final Uploader uploader;
+
     @PersistenceContext
     private EntityManager manager;
 
-    @InitBinder
+    @Autowired
+    public ProductController(Uploader uploader) {this.uploader = uploader;}
+
+    @InitBinder(value = "newProduct")
     public void init(WebDataBinder binder) {
         binder.addValidators(new DistinctFeatureNameValidator());
     }
 
     @PostMapping
-    public ResponseEntity<Void> newProduct(@RequestBody @Valid NewProductRequest request, @AuthenticationPrincipal
-        AuthenticatedUser authenticatedUser) {
+    public ResponseEntity<Void> newProduct(@RequestBody @Valid NewProductRequest request,
+        @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
         User user = authenticatedUser.getUser();
         Product product = request.toModel(manager, user);
         manager.persist(product);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{id}/imagens")
+    public ResponseEntity<Void> addPictures(@PathVariable Long id, @Valid NewPicturesRequest request,
+        @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+        User user = authenticatedUser.getUser();
+        Product product = Optional.ofNullable(manager.find(Product.class, id))
+            .orElseThrow(() -> new ResponseStatusException(
+                HttpStatus.NOT_FOUND,
+                "Não existe um produto com a id " + id
+            ));
+        if (!product.belongsTo(user)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Acesso negado");
+        }
+        product.addPictures(uploader.upload(request.getPictures()));
+        manager.merge(product);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/product/picture/NewPicturesRequest.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/product/picture/NewPicturesRequest.java
@@ -1,0 +1,20 @@
+package br.com.zupacademy.ggwadera.mercadolivre.product.picture;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
+
+public class NewPicturesRequest {
+
+    @NotEmpty
+    private List<MultipartFile> pictures;
+
+    public List<MultipartFile> getPictures() {
+        return pictures;
+    }
+
+    public void setPictures(List<MultipartFile> pictures) {
+        this.pictures = pictures;
+    }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/product/picture/ProductPicture.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/product/picture/ProductPicture.java
@@ -1,0 +1,56 @@
+package br.com.zupacademy.ggwadera.mercadolivre.product.picture;
+
+import br.com.zupacademy.ggwadera.mercadolivre.product.Product;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.validator.constraints.URL;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+@Entity
+public class ProductPicture {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @URL
+    @NaturalId
+    @Column(nullable = false, columnDefinition = "text")
+    private String uri;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private Product product;
+
+    @Deprecated
+    public ProductPicture() {
+    }
+
+    public ProductPicture(@NotBlank String uri, @NotNull Product product) {
+        this.uri = uri;
+        this.product = product;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProductPicture that = (ProductPicture) o;
+        return uri.equals(that.getUri()) && product.equals(that.getProduct());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uri, product);
+    }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/product/picture/Uploader.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/product/picture/Uploader.java
@@ -1,0 +1,12 @@
+package br.com.zupacademy.ggwadera.mercadolivre.product.picture;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Collection;
+import java.util.Set;
+
+public interface Uploader {
+
+    Set<String> upload(Collection<MultipartFile> pictures);
+
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/product/picture/UploaderFake.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/product/picture/UploaderFake.java
@@ -1,0 +1,20 @@
+package br.com.zupacademy.ggwadera.mercadolivre.product.picture;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Component
+public class UploaderFake implements Uploader {
+
+    @Override
+    public Set<String> upload(Collection<MultipartFile> pictures) {
+        return pictures.stream()
+            .map(picture -> "https://fake.site/" + UUID.randomUUID() + "_" + picture.getOriginalFilename())
+            .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/user/User.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/mercadolivre/user/User.java
@@ -10,6 +10,7 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 public class User {
@@ -54,5 +55,18 @@ public class User {
 
     public LocalDateTime getCreatedAt() {
         return createdAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return getId().equals(user.getId()) && getEmail().equals(user.getEmail());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getEmail());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,11 @@ spring:
       hibernate:
         format_sql: true
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 server:
   error:
     include-stacktrace: never


### PR DESCRIPTION
### Explicação

Com um produto cadastrado, um usuário logado pode adicionar imagens ao seu produto. Não precisa salvar a imagem em algum cloud ou no próprio sistema de arquivos. Cada arquivo de imagem pode virar um link ficticio que pode ser adicionado ao produto. 

### **Necessidades**

*  Adicionar uma ou mais imagens a um determinado produto do próprio usuário

### **Restrições**

*  Tem uma ou mais fotos
*  Só pode adicionar fotos ao produto que pertence ao próprio usuário

### Resultado esperado

*   Imagens adicionadas e 200 como retorno
*   Caso dê erro de validação retorne 400 e o json dos erros
*   Caso tente adicionar imagens a um produto que não é seu retorne 403.